### PR TITLE
chore: Allow to set the base url via an env variable TASMO_BASEURL

### DIFF
--- a/tasmoadmin/includes/top.php
+++ b/tasmoadmin/includes/top.php
@@ -27,6 +27,9 @@
 		    = $subdir = str_replace( "\\", "/", $subdir );
 	$subdir = $subdir == "//" ? "/" : $subdir;
 
+  if ($baseurl_from_env = getenv('TASMO_BASEURL')) {
+	  $subdir = $baseurl_from_env;
+	}
 
 	define( "_BASEURL_", $subdir );
 	define( '_APPROOT_', dirname( dirname( __FILE__ ) ).'/' );


### PR DESCRIPTION
This is especially useful when running the application with a reverse proxy which
maps the URL to something different which can not be autodetected.