### PR TITLE
Update devices_autoscan.php

### DIFF
--- a/tasmoadmin/pages/devices_autoscan.php
+++ b/tasmoadmin/pages/devices_autoscan.php
@@ -199,7 +199,7 @@
 					<label for="device_password">
 						<?php echo __( "DEVICE_PASSWORD", "DEVICE_ACTIONS" ); ?>
 					</label>
-					<input type="text"
+					<input type="password"
 					       class="form-control"
 					       id="device_password"
 					       name='device_password'


### PR DESCRIPTION
Changed input type for the device_password field from text to password. Currently the password is showing in plain text when you type. This allows a shoulder surfing attack.

Maybe add a option to show the password in plaintext if a user wants to check if they typed it correctly