### PR TITLE
Adds a filter for the device list view

### DIFF
--- a/tasmoadmin/lang/lang_en.ini
+++ b/tasmoadmin/lang/lang_en.ini
@@ -349,7 +349,7 @@ WIFICONFIG = "Wifi Config"
 VCC = "Vcc"
 ALL_OFF = "ALL OFF"
 BTN_UNLOCK_TOOLTIP = "Unlock protected devices for 60s"
-
+FILTER = "Filter..."
 
 [SELFUPDATE]
 NO_UPDATE_FOUND = "No update found"

--- a/tasmoadmin/pages/devices.php
+++ b/tasmoadmin/pages/devices.php
@@ -11,6 +11,16 @@ $devices = $Sonoff->getDevices();
 		<?php if (isset($devices) && !empty($devices)): ?>
 			<div class='row mb-1 mt-3'>
 				<div class="col col-auto offset-0 offset-xl-1">
+					<div class="form-group">
+						<input 	type="text" 
+								id="filterInput" 
+								class='form-control' 
+								onkeyup="device_filter()" 
+								placeholder="<?php echo __("FILTER", "DEVICES"); ?>"
+						>
+					</div>
+				</div>
+				<div class="col col-auto offset-0 offset-xl-1">
 					<div class="form-check pl-0">
 						<input type="checkbox"
 							   class="form-check-input showmore d-none"
@@ -560,3 +570,4 @@ $devices = $Sonoff->getDevices();
 <?php include "elements/modal_delete_device.php"; ?>
 
 <script src="<?php echo UrlHelper::JS("devices"); ?>"></script>
+<script src="<?php echo UrlHelper::JS("device_filter"); ?>"></script>

--- a/tasmoadmin/resources/js/device_filter.js
+++ b/tasmoadmin/resources/js/device_filter.js
@@ -1,0 +1,24 @@
+
+function device_filter() {
+
+	// var input, filter, table, tr, td, i, txtValue;
+	var input = document.getElementById("filterInput");
+	var filter = input.value.toLowerCase();
+	
+	var table = document.getElementById("device-list");
+	var tr = table.getElementsByTagName("tr");
+
+	for (var i = 0; i < tr.length; i++) {
+		var td = tr[i].getElementsByTagName("td")[3];
+
+		if (td) {
+			var txtValue = td.innerText.trim().replace(/\s+/g, ' ');
+		
+			if (txtValue.toLowerCase().indexOf(filter) > -1) {
+				tr[i].style.display = "";
+			} else {
+				tr[i].style.display = "none";
+			}
+		}
+	}
+}


### PR DESCRIPTION
An input field for an instant filter is displayed on top of the device list. Devices without a match in the name will be hidden while typing the filter...

For instance, by typing "Light", only devices matching "Light" in their name will be shown in the list.  The filter is case-insensitive.

The placement of the input field may need change.

![2020-09-21_15h43_05](https://user-images.githubusercontent.com/1495412/93775942-4df24780-fc23-11ea-8dc0-185e0817d5a1.jpg)
