### PR TITLE
Remove clear_env from docker php config

### DIFF
--- a/.docker/rootfs/etc/php7/php-fpm.d/www.conf
+++ b/.docker/rootfs/etc/php7/php-fpm.d/www.conf
@@ -8,4 +8,4 @@ pm.start_servers = 3
 pm.min_spare_servers = 2
 pm.max_spare_servers = 5
 pm.max_requests = 1024
-clear_env = yes
+clear_env = no


### PR DESCRIPTION
Currently, the environment variables for php-fpm in the docker image are all cleared. This makes it impossible to set a custom url prefix via TASMO_BASEURL, which is needed to run TasmoAdmins Docker image behind a reverse proxy. 
Leaving the env intact will probably fix the issue #140 and definitely #183