### PR TITLE
Init of release

### DIFF
--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -22,7 +22,7 @@ LABEL \
 
 # Setup Qemu
 ARG QEMU_ARCH
-COPY tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
+COPY _tmp/qemu-${QEMU_ARCH}-static /usr/bin/qemu-${QEMU_ARCH}-static
 
 # Install base system
 ARG BUILD_ARCH=arm32v6

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -23,6 +23,7 @@ main() {
             ;;
         *)
             echo "none of above!"
+            exit 1
     esac
 }
 

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -27,12 +27,6 @@ main() {
 }
 
 docker_prepare() {
-    # Prepare the machine before any code installation scripts
-    setup_dependencies
-
-    # # Update docker configuration to enable docker manifest command
-    # update_docker_configuration
-
     # Prepare qemu to build images other then x86_64 on travis
     prepare_qemu
 }
@@ -181,31 +175,6 @@ docker_manifest_list_version_os_arch() {
   docker manifest push $TARGET:$BUILD_VERSION-alpine-arm64v8
 }
 
-setup_dependencies() {
-  echo "PREPARE: Setting up dependencies."
-  docker info
-}
-
-update_docker_configuration() {
-  echo "PREPARE: Updating docker configuration"
-
-  mkdir $HOME/.docker
-
-  # enable experimental to use docker manifest command
-  echo '{
-    "experimental": "enabled"
-  }' | tee $HOME/.docker/config.json
-
-  # enable experimental
-  echo '{
-    "experimental": true,
-    "storage-driver": "overlay2",
-    "max-concurrent-downloads": 100,
-    "max-concurrent-uploads": 100
-  }' | sudo tee /etc/docker/daemon.json
-
-  sudo service docker restart
-}
 
 prepare_qemu(){
     echo "PREPARE: Qemu"

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -180,7 +180,7 @@ prepare_qemu(){
     echo "PREPARE: Qemu"
     # Prepare qemu to build non amd64 / x86_64 images
     docker run --rm --privileged multiarch/qemu-user-static:register --reset
-    pushd tmp &&
+    pushd _tmp &&
     curl -L -o qemu-x86_64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-x86_64-static.tar.gz && tar xzf qemu-x86_64-static.tar.gz &&
     curl -L -o qemu-arm-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-arm-static.tar.gz && tar xzf qemu-arm-static.tar.gz &&
     curl -L -o qemu-aarch64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-aarch64-static.tar.gz && tar xzf qemu-aarch64-static.tar.gz &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,3 +45,8 @@ jobs:
       run: ./.docker/docker.sh test
     - name: Package
       run: make package
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            _releases/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: main
 
-on:
+on:  
   push:
     branches: [master]
+    tags:
+      - '*'
   pull_request: ~
 
 env:
@@ -17,7 +19,6 @@ jobs:
       BUILD_VERSION: ${{ github.ref_name }}
     steps:
     - uses: actions/checkout@master
-    - run: echo "$BUILD_REF $BUILD_VERSION"
     - name: Prepare
       run: |
         mkdir tmp
@@ -26,3 +27,20 @@ jobs:
       run: ./.docker/docker.sh build
     - name: Test docker images
       run: ./.docker/docker.sh test
+  release:
+    runs-on: ubuntu-20.04
+    env:
+      BUILD_REF: ${{ github.sha }}
+      BUILD_VERSION: ${{ github.ref_name }}
+    steps:
+    - uses: actions/checkout@master
+    - name: Prepare
+      run: |
+        mkdir tmp
+        ./.docker/docker.sh prepare
+    - name: Build docker images
+      run: ./.docker/docker.sh build
+    - name: Test docker images
+      run: ./.docker/docker.sh test
+    - name: Package
+      run: make package

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,6 @@ jobs:
       run: make package
     - name: Create GitHub release
       uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            _releases/*
+      with:
+        files: |
+          _releases/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,19 @@ jobs:
       run: |
         mkdir _tmp
         ./.docker/docker.sh prepare
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build docker images
       run: ./.docker/docker.sh build
     - name: Test docker images
       run: ./.docker/docker.sh test
+    - name: Push all docker images
+      run: ./.docker/docker.sh push
+    - name: Create and push manifest list
+      run: ./.docker/docker.sh manifest-list
     - name: Package
       run: make package
     - name: Create GitHub release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: main
 
-on:  
+on:
   push:
     branches: [master]
     tags:
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Prepare
       run: |
-        mkdir tmp
+        mkdir _tmp
         ./.docker/docker.sh prepare
     - name: Build docker images
       run: ./.docker/docker.sh build
@@ -29,6 +29,7 @@ jobs:
       run: ./.docker/docker.sh test
   release:
     runs-on: ubuntu-20.04
+    if: ${{ github.ref_type == 'tag' }}
     env:
       BUILD_REF: ${{ github.sha }}
       BUILD_VERSION: ${{ github.ref_name }}
@@ -36,7 +37,7 @@ jobs:
     - uses: actions/checkout@master
     - name: Prepare
       run: |
-        mkdir tmp
+        mkdir _tmp
         ./.docker/docker.sh prepare
     - name: Build docker images
       run: ./.docker/docker.sh build

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ tasmoadmin/data/devices_all.csv
 /portable/xampp
 /portable/xampp_draft.zip
 !/portable/xampp.zip.*
+/_tmp/
+/_releases/
+portable/xampp.zip

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.DEFAULT_GOAL := package
+
+BUILD_VERSION ?= dev
+
+
+clean:
+	rm -rf _releases
+	rm -rf _tmp
+
+package: clean
+	mkdir _releases
+	mkdir _tmp
+	tar -zcf ./_releases/tasmoadmin_${BUILD_VERSION}.tar.gz tasmoadmin
+	zip -q -r ./_releases/tasmoadmin_${BUILD_VERSION}.zip tasmoadmin
+	cat portable/xampp.zip.* > portable/xampp.zip
+	unzip -q portable/xampp.zip -d _tmp/
+	cp -R tasmoadmin _tmp/xampp/htdocs/
+	cp -R portable/root_xampp/* _tmp/xampp/
+	zip -q -r ./_releases/tasmoadmin_${BUILD_VERSION}_xampp_portable.zip _tmp/xampp
+


### PR DESCRIPTION
- Wire up release flow (untested, any may fail)
- Add `Makefile` for packaging simplicity
- Make docker script exit 1 on wrong input (will cause CI to fail if so)

I think there could be lots of improvements still to be made. e.g. within the dockerfiles themselves and drop qemu to do multiarch builds simplier, but thats outside the scope of this.
