### PR TITLE
Fix loading versions by passing user-agent

### DIFF
--- a/tasmoadmin/pages/upload.php
+++ b/tasmoadmin/pages/upload.php
@@ -180,11 +180,7 @@ elseif (isset($_REQUEST["auto"])) {
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-		curl_setopt(
-			$ch,
-			CURLOPT_USERAGENT,
-			'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.13) Gecko/20080311 Firefox/2.0.0.13'
-		);
+		curl_setopt($ch, CURLOPT_USERAGENT, "TasmoAdmin/{$Config->read('current_git_tag')}" );
 		$result = curl_exec($ch);
 		curl_close($ch);
 		

--- a/tasmoadmin/pages/upload_form.php
+++ b/tasmoadmin/pages/upload_form.php
@@ -7,6 +7,8 @@ $ch       = curl_init();
 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 5);
 curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_USERAGENT, "TasmoAdmin/{$Config->read('current_git_tag')}" );
+
 
 $releaselogUrl = "https://raw.githubusercontent.com/arendst/Tasmota/development/RELEASENOTES.md?r=" . time();
 


### PR DESCRIPTION
The GitHub API requires passing a User-Agent so this was always failing.

By leveraging the version stored in the config we can provide them with something usable in their logs if they ever need to reach out to us.