### PR TITLE
make sure vsprintf() is called with array

### DIFF
--- a/tasmoadmin/libs/phpi18n/i18n.class.php
+++ b/tasmoadmin/libs/phpi18n/i18n.class.php
@@ -207,7 +207,7 @@
 				            .$this->compile( $config )
 				            .'public static function __callStatic($string, $args) {'
 				            ."\n"
-				            .'$args = array_shift($args);'
+				            .'$args = (array)array_shift($args);'
 				            ."\n"
 				
 				            .'    return vsprintf(constant("self::" . $string), $args);'


### PR DESCRIPTION
array_shift() returns NULL if the array is empty. In PHP8, vsprintf() throws an error if the second parameter is not an array.
Casting NULL to an array creates an empty array.

This fixes #423.

Not sure yet if this is the only change to be made for PHP8 compatibility but at least I can log in and check further...