### PR TITLE
Improve docker build process

### DIFF
--- a/.docker/Dockerfile.alpine-tmpl
+++ b/.docker/Dockerfile.alpine-tmpl
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=arm32v6/alpine:3.12
+ARG BUILD_FROM=arm32v6/alpine:3.15
 FROM ${BUILD_FROM}
 
 # Build arguments

--- a/.docker/docker.sh
+++ b/.docker/docker.sh
@@ -2,7 +2,11 @@
 set -o errexit
 
 TARGET=raymondmm/tasmoadmin
-QEMU_VERSION=v2.12.0
+QEMU_VERSION=v6.1.0-8
+ALPINE_VERSION=3.15
+BUILD_REF=${BUILD_REF:=dev}
+BUILD_VERSION=${BUILD_VERSION:=dev}
+
 
 main() {
     case $1 in
@@ -37,9 +41,9 @@ docker_prepare() {
 
 docker_build() {
     echo "DOCKER BUILD: Build all docker images."
-    docker build --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=amd64/alpine --build-arg BUILD_ARCH=amd64 --build-arg QEMU_ARCH=x86_64 --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-amd64 .
-    docker build --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=arm32v6/alpine --build-arg BUILD_ARCH=arm32v6 --build-arg QEMU_ARCH=arm --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-arm32v6 .
-    docker build --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=arm64v8/alpine --build-arg BUILD_ARCH=aarch64 --build-arg QEMU_ARCH=aarch64 --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-arm64v8 .
+    docker build --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=amd64/alpine:${ALPINE_VERSION} --build-arg BUILD_ARCH=amd64 --build-arg QEMU_ARCH=x86_64 --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-amd64 .
+    docker build --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=arm32v6/alpine:${ALPINE_VERSION} --build-arg BUILD_ARCH=arm32v6 --build-arg QEMU_ARCH=arm --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-arm32v6 .
+    docker build --build-arg BUILD_REF=${BUILD_REF} --build-arg BUILD_DATE=$(date +"%Y-%m-%dT%H:%M:%SZ") --build-arg BUILD_VERSION=${BUILD_VERSION} --build-arg BUILD_FROM=arm64v8/alpine:${ALPINE_VERSION} --build-arg BUILD_ARCH=aarch64 --build-arg QEMU_ARCH=aarch64 --file ./.docker/Dockerfile.alpine-tmpl --tag ${TARGET}:build-alpine-arm64v8 .
 }
 
 docker_test() {
@@ -183,6 +187,7 @@ docker_manifest_list_version_os_arch() {
 prepare_qemu(){
     echo "PREPARE: Qemu"
     # Prepare qemu to build non amd64 / x86_64 images
+    mkdir -p _tmp
     docker run --rm --privileged multiarch/qemu-user-static:register --reset
     pushd _tmp &&
     curl -L -o qemu-x86_64-static.tar.gz https://github.com/multiarch/qemu-user-static/releases/download/$QEMU_VERSION/qemu-x86_64-static.tar.gz && tar xzf qemu-x86_64-static.tar.gz &&

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,7 @@
 /portable/
 /.git/
+/tasmoadmin/data/firmwares/*
+/tasmoadmin/data/devices.csv
+/tasmoadmin/data/devices_bk.csv
+/tasmoadmin/data/MyConfig.php
+/tasmoadmin/data/MyConfig.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+/portable/
+/.git/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     - uses: actions/checkout@master
     - name: Prepare
       run: |
-        mkdir _tmp
         ./.docker/docker.sh prepare
     - name: Login to Docker Hub
       uses: docker/login-action@v1


### PR DESCRIPTION
- Use latest alpine image as base
- Bump QEMU version
- Include `.dockerignore` to improve build times
- Set default values in `docker.sh` to ease testing

To test


```bash
./.docker/docker.sh prepare
./.docker/docker.sh build
```